### PR TITLE
Update sinatra.html.md

### DIFF
--- a/source/docs/sinatra.html.md
+++ b/source/docs/sinatra.html.md
@@ -57,11 +57,11 @@ with all the custom opal paths added automatically.
 
 This `env` object includes all the opal corelib and stdlib paths. To add
 any custom application directories, you must add them to the load path using
-`env.append_path`. You can now add an `opal/application.rb` file into this
+`env.append_path`. You can now add an `app/application.rb` file into this
 added path with some basic content:
 
 ```ruby
-# opal/application.rb
+# app/application.rb
 require 'opal'
 
 puts "wow, running ruby!"


### PR DESCRIPTION
Hello! The Opal in Sinatra application example does not work for me. Looking into the suggested `Opal::Server` configuration, it seems that the `application.rb` file should be added into `app` folder, not `opal` folder. It works for me. Here is a tiny pull request to update this doc.